### PR TITLE
Update default value of `ApiUrl` and Add lock files on .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,8 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
+
+# lock files
+package-lock.json
+yarn.lock
+pnpm-lock.yaml

--- a/src/configs/index.ts
+++ b/src/configs/index.ts
@@ -4,7 +4,7 @@ interface ConfigType {
 }
 
 const config: ConfigType = {
-	ApiUrl: process.env.NEXT_PUBLIC_SHAREBOOK_API ?? 'https://sharebook.com.br/api/',
+	ApiUrl: process.env.NEXT_PUBLIC_SHAREBOOK_API ?? 'https://dev.sharebook.com.br/api/',
 	viaCepUrl: 'https://viacep.com.br/'
 };
 


### PR DESCRIPTION
## Description

- Add lock files on .gitignore
- Set default `ApiUrl` (`@sharebook-configs`)